### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,10 +33,17 @@ const signinLimiter = rateLimit({
     message: 'Too many login attempts from this IP, please try again after 15 minutes.'
 });
 
+// Rate limiter for profile access to protect DB
+const profileLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per window per IP to /profile/:id
+    message: 'Too many requests to profiles from this IP, please try again after 15 minutes.'
+});
+
 app.get('/', (req,res) => {res.send('it is working!');})
 app.post('/Signin', signinLimiter, signin.handleSignin(db, bcrypt))
 app.post('/register',(req, res) => {register.handleRegister(req, res, db, bcrypt) }) //dependencies injection
-app.get('/profile/:id', (req,res) => {profile.handleProfileGet(req, res, db)})
+app.get('/profile/:id', profileLimiter, (req,res) => {profile.handleProfileGet(req, res, db)})
 app.put('/image', (req,res) => {image.handleImage(req, res, db)})
 app.post('/imageurl', (req,res) => {image.handleApiCall(req,res)})
 


### PR DESCRIPTION
Potential fix for [https://github.com/iamjatinchauhan/facerecognitionbrain-api/security/code-scanning/2](https://github.com/iamjatinchauhan/facerecognitionbrain-api/security/code-scanning/2)

To fix the problem, we should apply an appropriate Express rate limiting middleware to the `/profile/:id` route, mirroring the approach already taken for `/Signin`. This involves instantiating a new rate limiter (with parameters tuned to reasonable usage; for example, allowing a user/client to fetch a limited number of profiles within a certain time window) and passing it as middleware specifically to the `/profile/:id` endpoint on line 39. Required changes are all within server.js and should include defining the new rate limiter and updating the route to use it. No changes to existing functionality are necessary; just the addition of rate limiting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
