### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -40,11 +40,18 @@ const profileLimiter = rateLimit({
     message: 'Too many requests to profiles from this IP, please try again after 15 minutes.'
 });
 
+// Rate limiter for image endpoint to protect DB
+const imageLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50, // max 50 requests per window per IP to /image
+    message: 'Too many requests to /image from this IP, please try again after 15 minutes.'
+});
+
 app.get('/', (req,res) => {res.send('it is working!');})
 app.post('/Signin', signinLimiter, signin.handleSignin(db, bcrypt))
 app.post('/register',(req, res) => {register.handleRegister(req, res, db, bcrypt) }) //dependencies injection
 app.get('/profile/:id', profileLimiter, (req,res) => {profile.handleProfileGet(req, res, db)})
-app.put('/image', (req,res) => {image.handleImage(req, res, db)})
+app.put('/image', imageLimiter, (req,res) => {image.handleImage(req, res, db)})
 app.post('/imageurl', (req,res) => {image.handleApiCall(req,res)})
 
 app.listen(process.env.PORT || 3000, () => {   //listens server request localhost:3000


### PR DESCRIPTION
Potential fix for [https://github.com/iamjatinchauhan/facerecognitionbrain-api/security/code-scanning/3](https://github.com/iamjatinchauhan/facerecognitionbrain-api/security/code-scanning/3)

To fix this issue, we need to add a rate limiting middleware to the `/image` route. Since similar logic is used for `/profile/:id` and `/Signin` routes, we will follow that pattern. First, we should define a new rate limiter (e.g., `imageLimiter`) using `express-rate-limit` with sensible defaults. This limiter will restrict the number of requests per IP to the `/image` endpoint over a certain time window (15 minutes, for example). Then, we apply this `imageLimiter` middleware to the `/image` route on line 47. We only need to edit sections of this file shown above.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
